### PR TITLE
The new timeout is 45 minutes on physical devices

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	maxTimeoutSeconds = 1800
+	maxTimeoutSeconds = 2700
 )
 
 // ConfigsModel ...


### PR DESCRIPTION
### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

The time limit on physical devices is 45 minutes, for example see [here](https://cloud.google.com/sdk/gcloud/reference/firebase/test/ios/run).

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

Bitrise will use 30 minutes as the maximum allowed timeout. This change increases the timeout to 45 minutes.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
